### PR TITLE
fix: crop and preview buttons should be disabled after canvas reset

### DIFF
--- a/src/js/dev/cropper.sidebar.js
+++ b/src/js/dev/cropper.sidebar.js
@@ -218,6 +218,7 @@ function resetCanvas() {
     cropperCanvas.selectedArea.setDefaultPos(translated.x, translated.y);
     cropperCanvas.addBackground();
     cropperCanvas.drawImage();
+    toggleButtons(true);
 }
 
 function insertChar(target, char) {


### PR DESCRIPTION
Closes #31 